### PR TITLE
Fix error if '=' is called without n1 and n2

### DIFF
--- a/src/logic/operate.js
+++ b/src/logic/operate.js
@@ -3,12 +3,11 @@ import Big from 'big.js';
 const operate = (numberOne, numberTwo, operation) => {
   let bigNumOne;
   let bigNumTwo;
-  if (operation !== '' && numberTwo !== '0') {
+  if (numberOne !== null && numberTwo !== null) {
     bigNumOne = new Big(numberOne);
     bigNumTwo = new Big(numberTwo);
   }
   let result;
-
   if (operation === '-') {
     result = Big(bigNumOne.minus(bigNumTwo));
   } else if (operation === '+') {


### PR DESCRIPTION
I missed error handling while only one number is given in initial calculations.